### PR TITLE
Add button accessibility override

### DIFF
--- a/examples/button/buttons.html
+++ b/examples/button/buttons.html
@@ -10,6 +10,7 @@
     <!-- ENDLIBS -->
 
     <script type="text/javascript" src="../../ext-all.js"></script>
+    <script type="text/javascript" src="../../overrides/ButtonOverride.js"></script>
 
     <script type="text/javascript" src="../form/states.js"></script>
     <script type="text/javascript" src="buttons.js"></script>

--- a/overrides/ButtonOverride.js
+++ b/overrides/ButtonOverride.js
@@ -1,0 +1,15 @@
+(function(){
+    var baseOnRender = Ext.Button.prototype.onRender;
+    Ext.override(Ext.Button, {
+        onRender: function(ct, position){
+            baseOnRender.call(this, ct, position);
+            var label = this.text || (this.tooltip && (this.tooltip.text || this.tooltip.title || this.tooltip));
+            if(label){
+                this.btnEl.dom.setAttribute('aria-label', label);
+            }
+            if(this.el && this.el.dom.tagName === 'TABLE'){
+                this.el.dom.setAttribute('role', 'presentation');
+            }
+        }
+    });
+})();


### PR DESCRIPTION
## Summary
- add accessibility override for `Ext.Button`
- load override in Button example

## Testing
- `npm run axe --silent -- examples/button/buttons.html` *(fails: Cannot find module './run-a11y.ts')*

------
https://chatgpt.com/codex/tasks/task_b_6870d3e2e934832e9d1b2fd86c6b9ddd